### PR TITLE
use Forwardable def_delagator instead

### DIFF
--- a/lib/skedplus/durationable.rb
+++ b/lib/skedplus/durationable.rb
@@ -1,7 +1,7 @@
 require "duration"
 
 module Skedplus::Durationable
-  def self.make_duration(str)
+  def make_duration(str)
     hours   = str.split(":").first
     minutes = str.split(":").last
     Duration.new(hours: hours, minutes: minutes)

--- a/lib/skedplus/flight.rb
+++ b/lib/skedplus/flight.rb
@@ -5,7 +5,7 @@ class Skedplus::Flight
   include Skedplus::Durationable
   extend Forwardable
   
-  def_delegators :@parser, :number, :tail, :org, :dest, :dep, :arr, :pax, :credit, :dpu, :dhd, :turn
+  def_delegators :@parser, :number, :tail, :org, :dest, :dep, :arr, :dpu
 
   def initialize(parser)
     @parser = parser
@@ -17,5 +17,21 @@ class Skedplus::Flight
 
   def block
     self.make_duration(@parser.block)
+  end
+
+  def pax
+    @parser.pax.to_i
+  end
+
+  def credit
+    self.make_duration(@parser.credit)
+  end
+
+  def dhd?
+    @parser.dhd == "D" ? true : false
+  end
+
+  def turn
+    self.make_duration(@parser.turn)
   end
 end

--- a/lib/skedplus/flight.rb
+++ b/lib/skedplus/flight.rb
@@ -3,16 +3,12 @@ require "skedplus/durationable"
 
 class Skedplus::Flight
   include Skedplus::Durationable
+  extend Forwardable
+  
+  def_delegators :@parser, :number, :tail, :org, :dest, :dep, :arr, :pax, :credit, :dpu, :dhd, :turn
 
   def initialize(parser)
     @parser = parser
-  end
-
-  %w{number tail org dest dep arr pax credit dpu dhd turn}
-  .each do |col|
-    define_method(col) do
-      @parser.send(col)
-    end
   end
 
   def sequence

--- a/spec/lib/skedplus/flight_spec.rb
+++ b/spec/lib/skedplus/flight_spec.rb
@@ -1,16 +1,23 @@
 require "skedplus/flight"
 
 RSpec.describe Skedplus::Flight do
-  before :all do
+  before :all do 
+    FakeParser = Struct.new(:sequence, :number, :tail, :org, :dest, :dep, :arr, :pax, :block, :credit, :dpu, :dhd, :turn)
+    fake_parser = FakeParser.new("1", "5001", "901", "ATL", "CHS", "12:34", "13:34", "32", "01:00", "01:12", "", "", "00:30")
+    @flight = Skedplus::Flight.new(fake_parser)
   end
 
   it "#sequence" do
+    expect(@flight.sequence).to be_a Integer
+    expect(@flight.sequence).to eq 1
   end
 
   it "#number" do
+    expect(@flight.number).to eq "5001"
   end
 
   it "#tail" do
+    expect(@flight.tail).to eq "901"
   end
 
   it "#org" do
@@ -26,20 +33,35 @@ RSpec.describe Skedplus::Flight do
   end
 
   it "#pax" do
+    expect(@flight.pax).to be_a Integer
+    expect(@flight.pax).to eq 32
   end
 
   it "#block" do
+    expect(@flight.block).to be_a Duration
+    expect(@flight.block.hours).to eq 1
+    expect(@flight.block.minutes).to eq 0
+    # expect(@flight.block.to_s).to eq ""
   end
 
   it "#credit" do
+    expect(@flight.credit).to be_a Duration
+    expect(@flight.credit.hours).to eq 1
+    expect(@flight.credit.minutes).to eq 12
+    # expect(@flight.credit.to_s).to eq ""
   end
 
   it "#dpu" do
   end
 
-  it "#dhd" do
+  it "#dhd?" do
+    expect(@flight.dhd?).to be_falsy
   end
 
   it "#turn" do
+    expect(@flight.turn).to be_a Duration
+    expect(@flight.turn.hours).to eq 0
+    expect(@flight.turn.minutes).to eq 30
+    # expect(@flight.turn.to_s).to eq ""
   end
 end


### PR DESCRIPTION
I can use [Forwardable](http://ruby-doc.org/stdlib-2.0.0/libdoc/forwardable/rdoc/Forwardable.html) instead of the `define_method` pattern I was using.

Thanks @jess.